### PR TITLE
Properly use intermediate certificates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: Main
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - "v*.*.*"
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup go1.19 Environment
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.19.3'
+      id: go
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Go dependencies cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.go-cache-paths.outputs.go-build }}
+          ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys:
+          ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          ${{ runner.os }}-go-
+    - name: Build and Test
+      run: |
+        go test ./... -race -coverprofile=coverage.out -covermode=atomic
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.19.3'
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.47.2
+          args: --timeout=3m0s --verbose

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -126,22 +126,23 @@ func verifySignature(cert *x509.Certificate, msg *cose.Sign1Message) error {
 }
 
 func verifyCertChain(cert *x509.Certificate, rootCert *x509.Certificate, cabundle [][]byte) error {
-	pool := x509.NewCertPool()
+	roots := x509.NewCertPool()
 
-	pool.AddCert(rootCert)
+	roots.AddCert(rootCert)
 
+	intermediates := x509.NewCertPool()
 	for _, certBy := range cabundle {
 		cert, err := x509.ParseCertificate(certBy)
 		if err != nil {
 			return err
 		}
 
-		pool.AddCert(cert)
+		intermediates.AddCert(cert)
 	}
 
 	opts := x509.VerifyOptions{
-		Roots:         pool,
-		Intermediates: x509.NewCertPool(),
+		Roots:         roots,
+		Intermediates: intermediates,
 		CurrentTime:   time.Now().UTC(),
 	}
 


### PR DESCRIPTION
Previously we were just putting all certificates in the root certificate pool. This could cause an issue where non-valid intermidiate certificates would be implicitly trusted like a root certificate.